### PR TITLE
Fix upsert for OAuth tokens

### DIFF
--- a/server/db/init.sql
+++ b/server/db/init.sql
@@ -45,5 +45,5 @@ CREATE TABLE IF NOT EXISTS oauth_tokens (
   scope TEXT,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (user_id) REFERENCES users(id)
-);
+  UNIQUE(user_id),
+  FOREIGN KEY (user_id) REFERENCES users(id));

--- a/server/tests/utils/testHelpers.js
+++ b/server/tests/utils/testHelpers.js
@@ -32,6 +32,7 @@ const initTestDatabase = async (db) => {
     scope TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id),
     FOREIGN KEY (user_id) REFERENCES users(id)
   )`);
 


### PR DESCRIPTION
## Summary
- make `user_id` unique on `oauth_tokens`
- upsert tokens in `updateUserTokens`
- update test DB schema
- ensure sqlite database is recreated cleanly for integration tests
- test inserting tokens for a new user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d939a88d4832880b40a15c8e8998b